### PR TITLE
Refactor: Standardize headers across all pages

### DIFF
--- a/30_days_progress.html
+++ b/30_days_progress.html
@@ -64,11 +64,11 @@
     </style>
 </head>
 <body class="antialiased">
-<header class="bg-stone-800 text-white shadow-md">
+<div>
     <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
         <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
     </div>
-</header>
+</div>
 
     <div class="container mx-auto p-4 md:p-8 max-w-7xl">
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -29,3 +29,29 @@ a:hover {
     color: #047857; /* teal-700 */
     text-decoration: underline;
 }
+
+/* Styles for the header on individual day pages */
+.jules-header-container {
+    position: relative;
+}
+
+.jules-return-button {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    border: 1px solid #d1d5db; /* gray-300 */
+    padding: 0.5rem 1rem; /* py-2 px-4 */
+    border-radius: 9999px; /* rounded-full */
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 500; /* font-medium */
+    color: #374151; /* gray-700 */
+    background-color: white;
+    transition: all 0.2s ease-in-out;
+    text-decoration: none;
+    z-index: 10;
+}
+
+.jules-return-button:hover {
+    background-color: #f9fafb; /* gray-50 */
+    border-color: #9ca3af; /* gray-400 */
+}

--- a/day_1.html
+++ b/day_1.html
@@ -43,16 +43,18 @@
             color: #333;
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 1: Introduction to Problem Solving</p>
+</div>
+</div>
     <div class="container mx-auto px-4 py-8 md:py-12 max-w-5xl">
 
         <div class="text-center mb-12">

--- a/day_10.html
+++ b/day_10.html
@@ -50,19 +50,18 @@
             }
         }
     </style>
+
 </head>
 <body>
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 10: Sliding Window (Fixed Size)</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 10: Sliding Window (Fixed Size)</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 md:p-8 max-w-5xl">
 
         <main>

--- a/day_11.html
+++ b/day_11.html
@@ -92,19 +92,18 @@
         }
 
     </style>
+
 </head>
 <body class="antialiased">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 11: Sliding Window (Variable Size)</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 11: Sliding Window (Variable Size)</p>
+</div>
+</div>
     <div class="container mx-auto px-4 py-8 md:py-12">
 
         <main>

--- a/day_12.html
+++ b/day_12.html
@@ -111,19 +111,18 @@
             100% { transform: rotate(360deg); }
         }
     </style>
+
 </head>
 <body class="bg-gray-50 text-gray-800 font-sans">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 12: Two Pointer Technique</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 12: Two Pointer Technique</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 md:p-8">
 
         <main>

--- a/day_13.html
+++ b/day_13.html
@@ -64,20 +64,19 @@
             }
         }
     </style>
+
 </head>
 <body class="antialiased">
 
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 13: Kadane's Algorithm</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 13: Kadane's Algorithm</p>
+</div>
+</div>
 
     <main class="container mx-auto p-4 md:p-8 space-y-12">
 

--- a/day_14.html
+++ b/day_14.html
@@ -37,19 +37,18 @@
         .nav-link.active { background-color: var(--border-color); font-weight: 600; color: var(--text-primary); }
         .contest-mode .solution-details, .contest-mode .reveal-btn { display: none; }
     </style>
+
 </head>
 <body class="antialiased">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 14: Arrays Contest</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 14: Arrays Contest</p>
+</div>
+</div>
     <!-- Chosen Palette: Warm Earth Tones -->
     <!-- Application Structure Plan: The app is a guided learning module with an optional "Contest Mode". A sticky sidebar provides navigation and progress tracking. The main content area features an introduction, a technique refresher, an accordion of four problems, and a final summary. Contest Mode adds a timer, a code editor, and initially hides solutions to simulate a test environment. A reset button appears after a mode is selected to provide an easy way back to the start. This structure allows for both guided learning and self-assessment, enhancing user engagement and skill retention. -->
     <!-- Visualization & Content Choices:

--- a/day_15.html
+++ b/day_15.html
@@ -75,19 +75,18 @@
             background-color: #475569; /* slate-600 */
         }
     </style>
+
 </head>
 <body class="text-slate-800">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 15: Sorting Basics</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 15: Sorting Basics</p>
+</div>
+</div>
     <div class="container mx-auto p-4 md:p-8">
 
         <div class="w-full max-w-7xl mx-auto bg-white rounded-xl shadow-lg p-4 sm:p-6">

--- a/day_16.html
+++ b/day_16.html
@@ -60,19 +60,18 @@
             }
         }
     </style>
+
 </head>
 <body class="antialiased">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 16: Efficient Sorting</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 16: Efficient Sorting</p>
+</div>
+</div>
 
     <div class="container mx-auto px-4 py-8 md:py-12">
 

--- a/day_17.html
+++ b/day_17.html
@@ -63,19 +63,18 @@
             max-height: 40vh;
         }
     </style>
+
 </head>
 <body class="text-slate-800">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 17: Sorting Applications</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 17: Sorting Applications</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
 

--- a/day_18.html
+++ b/day_18.html
@@ -74,19 +74,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+
 </head>
 <body class="antialiased">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 18: Bit Manipulation Basics</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 18: Bit Manipulation Basics</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
 
         <main class="space-y-12">

--- a/day_19.html
+++ b/day_19.html
@@ -52,20 +52,19 @@
             font-size: 0.875rem;
         }
     </style>
+
 </head>
 <body class="bg-slate-50 text-slate-800">
 
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 19: Advanced Bit Tricks</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 19: Advanced Bit Tricks</p>
+</div>
+</div>
 
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         

--- a/day_2.html
+++ b/day_2.html
@@ -46,16 +46,18 @@
             border-color: #3b82f6;
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Time Complexity Interactive Guide</p>
+</div>
+</div>
 
     <div class="bg-white shadow-sm sticky top-0 z-10">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/day_20.html
+++ b/day_20.html
@@ -76,19 +76,18 @@
             background-color: #64748b;
         }
     </style>
+
 </head>
 <body class="bg-slate-100">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 20: Applications of Bit Manipulation</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 20: Applications of Bit Manipulation</p>
+</div>
+</div>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
 

--- a/day_21.html
+++ b/day_21.html
@@ -56,19 +56,18 @@
             max-height: 450px;
         }
     </style>
+
 </head>
 <body class="antialiased">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=3" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 21: Sorting & Bit Manipulation</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=3" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 21: Sorting & Bit Manipulation</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-12">
 

--- a/day_22.html
+++ b/day_22.html
@@ -50,19 +50,18 @@
             }
         }
     </style>
+
 </head>
 <body class="text-slate-800">
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 22: C# String Basics</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 22: C# String Basics</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 md:p-8 max-w-7xl">
 

--- a/day_23.html
+++ b/day_23.html
@@ -68,16 +68,18 @@
             to { opacity: 1; transform: translateY(0); }
         }
     </style>
+
 </head>
 <body class="bg-slate-50 text-slate-800">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 23: Anagrams & Frequency Maps</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
 
         <div class="text-center mb-12">

--- a/day_24.html
+++ b/day_24.html
@@ -108,16 +108,18 @@
             background-color: #bbf7d0;
         }
     </style>
+
 </head>
 <body class="text-gray-800">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">30-Day Daily Roadmap: Problem Solving</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 md:p-8">
         <div class="text-center mb-8">

--- a/day_25.html
+++ b/day_25.html
@@ -28,16 +28,18 @@
         .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 300px; max-height: 400px; }
         @media (min-width: 768px) { .chart-container { height: 350px; } }
     </style>
+
 </head>
 <body class="bg-slate-50 text-slate-800">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">30-Day Problem Solving Roadmap</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
         <div class="text-center mb-10">

--- a/day_26.html
+++ b/day_26.html
@@ -53,16 +53,18 @@
             transition: max-height 0.5s ease-in-out;
         }
     </style>
+
 </head>
 <body class="antialiased">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 26: String Hashing Concepts</p>
+</div>
+</div>
 
     <div class="bg-white shadow-sm sticky top-0 z-10">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/day_27.html
+++ b/day_27.html
@@ -48,16 +48,18 @@
             max-height: 400px;
         }
     </style>
+
 </head>
 <body class="antialiased">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">30-Day Problem Solving Roadmap</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 md:p-8 max-w-5xl">
         <div class="text-center mb-8">
             <h1 class="text-3xl sm:text-4xl font-bold text-slate-900">30-Day Problem Solving Roadmap</h1>

--- a/day_28.html
+++ b/day_28.html
@@ -61,16 +61,18 @@
             border-bottom: 3px solid #f28482;
         }
     </style>
+
 </head>
 <body class="antialiased">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=4" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 28: Contest Simulation (Enhanced)</p>
+</div>
+</div>
     <div class="container mx-auto px-4 py-8 max-w-7xl">
         <div class="text-center mb-8">
             <h1 class="text-4xl font-bold text-[#2C534C]">30-Day Intermediate Problem Solving</h1>

--- a/day_29.html
+++ b/day_29.html
@@ -45,16 +45,18 @@
         .code-block .comment { color: #6a9955; }
         .code-block .method { color: #dcdcaa; }
     </style>
+
 </head>
 <body class="font-sans antialiased text-gray-800">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=5" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 29: C# Revision Roadmap</p>
+</div>
+</div>
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
 

--- a/day_3.html
+++ b/day_3.html
@@ -34,16 +34,18 @@
             }
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Understanding Space Complexity in C#</p>
+</div>
+</div>
     <div class="container mx-auto px-4 py-8 md:py-12">
         <div class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-bold text-gray-800">Understanding Space Complexity</h1>

--- a/day_30.html
+++ b/day_30.html
@@ -65,16 +65,18 @@
             background: #B6A99A;
         }
     </style>
+
 </head>
 <body class="flex flex-col h-screen overflow-hidden">
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=4" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=5" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Interactive 30-Day Problem Solving Roadmap</p>
+</div>
+</div>
     <div class="bg-white shadow-sm z-30 border-b border-gray-200">
         <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex items-center justify-between">
             <h1 class="text-2xl font-bold text-[#6D5B4F]">Intermediate Problem Solving Roadmap</h1>

--- a/day_4.html
+++ b/day_4.html
@@ -36,16 +36,18 @@
     <!-- Application Structure Plan: A tab-based single-page application is used to present the content in a structured, digestible manner. The navigation allows users to switch between three core learning modules: 'Debugging Techniques', 'Handling Corner Cases', and 'Practice Problems'. This structure mirrors a logical learning progression from theory to practical application. The interactive elements, such as toggles for problem/solution views and accordions for practice questions, are designed to engage the user and reinforce learning by encouraging active participation rather than passive reading. -->
     <!-- Visualization & Content Choices: The information is primarily textual and code-based. The presentation relies on structured HTML, Tailwind CSS, and icons for clarity. Goal: Explain Debugging -> Presentation: Side-by-side text and code blocks with icons -> Interaction: None, focus on readability. Goal: Compare good/bad practices for Corner Cases -> Presentation: Cards with code snippets -> Interaction: A toggle button to switch between the flawed and robust code, encouraging direct comparison. Goal: Test Knowledge with Practice Problems -> Presentation: Accordion layout -> Interaction: Click to expand a problem, then click a button to reveal the solution and explanation. This prevents spoilers and promotes critical thinking. No data charts are needed, so no charting libraries are used. -->
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">C# Debugging & Edge Cases Guide</p>
+</div>
+</div>
     <div class="container mx-auto p-4 md:p-8 max-w-7xl">
         <div class="text-center mb-8">
             <h1 class="text-4xl md:text-5xl font-bold text-gray-800">Day 4: Dry Runs & Edge Cases in C#</h1>

--- a/day_5.html
+++ b/day_5.html
@@ -57,16 +57,18 @@
             border-color: #ef4444 !important;
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">C# Fundamentals Explorer</p>
+</div>
+</div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
         <div class="text-center mb-8">
             <h1 class="text-4xl font-bold text-sky-600">C# Fundamentals Explorer</h1>

--- a/day_6.html
+++ b/day_6.html
@@ -34,16 +34,18 @@
             }
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 6: Contest Simulation | 30-Day Problem Solving Roadmap</p>
+</div>
+</div>
     <div class="bg-white/80 backdrop-blur-lg shadow-sm sticky top-0 z-50">
         <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">

--- a/day_7.html
+++ b/day_7.html
@@ -46,16 +46,18 @@
             background-color: #d1d5db;
         }
     </style>
+
 </head>
 <body>
-<header class="bg-stone-800 text-white shadow-md">
-    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
-        <h1 class="text-xl md:text-2xl font-bold">Problem Solving Roadmap</h1>
-        <a href="30_days_progress.html?week=1" class="text-sm md:text-base bg-stone-600 hover:bg-stone-500 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=1" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 7: Review & Revision</p>
+</div>
+</div>
     <div class="container mx-auto p-4 md:p-8">
         <div class="text-center mb-8">
             <h1 class="text-4xl font-bold text-teal-700">30-Day Problem Solving Roadmap</h1>

--- a/day_8.html
+++ b/day_8.html
@@ -61,19 +61,18 @@
             transform: scale(1.1);
         }
     </style>
+
 </head>
 <body>
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 8: C# Array Basics & Rotations</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 8: C# Array Basics & Rotations</p>
+</div>
+</div>
     <div id="app" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
 
 

--- a/day_9.html
+++ b/day_9.html
@@ -57,19 +57,18 @@
             background-color: #D1D5DB; /* gray-300 */
         }
     </style>
+
 </head>
 <body>
-<header>
-    <div class="container mx-auto px-4 pt-8">
-        <a href="30_days_progress.html?week=2" class="text-sm md:text-base text-teal-700 hover:text-teal-600 font-semibold">
-            &larr; Back to Roadmap
-        </a>
-    </div>
-    <div class="text-center pt-4 pb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
-        <p class="text-lg md:text-xl text-gray-600 mt-2">Day 9: Prefix & Suffix Arrays</p>
-    </div>
-</header>
+<div class="jules-header-container">
+    <a href="30_days_progress.html?week=2" class="jules-return-button">
+    &larr; Return to Homepage
+</a>
+    <div class="text-center pt-8 pb-8">
+    <h1 class="text-4xl md:text-5xl font-bold text-teal-800">Intermediate Problem Solving</h1>
+    <p class="text-lg md:text-xl text-gray-600 mt-2">Day 9: Prefix & Suffix Arrays</p>
+</div>
+</div>
 
     <main class="max-w-6xl mx-auto py-8 px-4 sm:px-6 lg:px-8 space-y-12">
         <!-- Introduction -->


### PR DESCRIPTION
This commit updates the headers across all 30 daily pages and the homepage to create a consistent and modern user experience.

Key changes:
- Removes the old, dark header banner from all pages.
- Implements a new, consistent header design on all `day_*.html` pages, featuring a large centered title and a "Return to Homepage" button in the top-right corner, as per the user's final design clarification.
- The button text has been updated from "Back to Roadmap" to "Return to Homepage" for clarity.
- The necessary CSS for the new header design has been added to the central `css/styles.css` file to avoid code duplication.
- The redundant header banner on the `30_days_progress.html` homepage has been removed while preserving the page title.